### PR TITLE
problema2-consulta-lenta

### DIFF
--- a/src/main/java/br/com/algaecommerce/HomeController.java
+++ b/src/main/java/br/com/algaecommerce/HomeController.java
@@ -74,7 +74,7 @@ public class HomeController {
 		}
 		
 		List<Produto> findAll() {
-			TypedQuery<Produto> typedQuery = manager.createQuery("select p from Produto p", Produto.class);
+			TypedQuery<Produto> typedQuery = manager.createQuery("select p from Produto p left join fetch p.tags", Produto.class);
 			List<Produto> lista = typedQuery.getResultList();
 			return new ArrayList<>(lista);
 		}

--- a/src/main/java/br/com/algaecommerce/HomeController.java
+++ b/src/main/java/br/com/algaecommerce/HomeController.java
@@ -47,7 +47,7 @@ public class HomeController {
 	//TODO Está lento em produção, local funciona.
 	@RequestMapping(value = "/produtos", method = RequestMethod.GET)
 	@Transactional
-	public @ResponseBody List<Produto> cadastrarUmProdutoNovo() {
+	public @ResponseBody List<Produto> listarProdutos() {
 		return new produtoRepository(m).findAll();
 	}
 	

--- a/src/main/java/br/com/algaecommerce/Produto.java
+++ b/src/main/java/br/com/algaecommerce/Produto.java
@@ -1,12 +1,6 @@
 package br.com.algaecommerce;
 
-import javax.persistence.CollectionTable;
-import javax.persistence.Column;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
+import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -21,7 +15,7 @@ public class Produto {
 	private String nome;
 	
 	private LocalDateTime dataCriacao;
-	
+
 	@ElementCollection(targetClass = String.class)
 	@CollectionTable(name = "produto_tag", joinColumns = @JoinColumn(name = "produto_id"))
 	@Column(name="nome")


### PR DESCRIPTION
Foi constatado um problema de N+1 na listagem de produtos, que estava deixando a consulta lenta em produção. O problema ocorre pois, a tabela de Produto tem relacionamento com produto_tag, pois, produto tem tags e a consulta estava fazendo um novo select para cada tag de produto. 

Para resolver esse problema, alterei a consulta de produtos adicionando um "left join fetch p.tags", dessa forma eu forço que a consulta faça um left join  (trazendo produtos mesmo que não tenha tag) e fica tudo em um único select.
Também alterei o nome do método para listarProdutos()